### PR TITLE
Fix heuristic scoring bug and complete headers

### DIFF
--- a/GameCore.h
+++ b/GameCore.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <chrono>
+#include <iostream>
 
 //––– Basic types & enums ––––––––––––––––––––––––––––––––––––––––––––––––––
 enum Color     { VACANT = 0, RED = 1, BLACK = 2 };
@@ -126,7 +127,25 @@ class SmartPlayer : public Player {
                  int alpha, int beta, AlarmClock& ac);
     int  evaluateState(const Scaffold& s, int N,
                        int color, int depth, AlarmClock& ac);
+    int  heuristicScore(const Scaffold& s, int N, int color);
     GameState checkState(const Scaffold& s, int N);
+};
+
+class GameImpl;  // defined in Game.cpp
+
+//-- Game facade that uses a private implementation -------------------------
+class Game {
+  public:
+    Game(int nColumns, int nLevels, int N,
+         Player* red, Player* black);
+    ~Game();
+    bool completed(int& winner) const;
+    bool takeTurn();
+    void play();
+    int  checkerAt(int c, int r) const;
+
+  private:
+    GameImpl* m_impl;
 };
 
 #endif // GAMECORE_H

--- a/Players.cpp
+++ b/Players.cpp
@@ -112,13 +112,13 @@ int SmartPlayer::evaluateState(const Scaffold& s, int N, int color, int depth, A
 
 int SmartPlayer::heuristicScore(const Scaffold& s, int N, int color) {
     int opp = (color == RED ? BLACK : RED);
-    auto scoreLine = [&](int c, int r, int dc, int dr) {
+    auto scoreLine = [&](int c, int r, int dc, int dr, int col) {
         int countColor = 0, countEmpty = 0;
         for (int i = 0; i < N; ++i) {
             int cc = c + i * dc, rr = r + i * dr;
             if (cc < 1 || cc > s.cols() || rr < 1 || rr > s.levels()) return 0;
             int cell = s.checkerAt(cc, rr);
-            if (cell == color) countColor++;
+            if (cell == col) countColor++;
             else if (cell == VACANT) countEmpty++;
             else return 0; // Blocked by opponent
         }
@@ -130,8 +130,8 @@ int SmartPlayer::heuristicScore(const Scaffold& s, int N, int color) {
     for (int c = 1; c <= s.cols(); ++c) {
         for (int r = 1; r <= s.levels(); ++r) {
             for (auto [dc, dr] : dirs) {
-                score += scoreLine(c, r, dc, dr);
-                score -= scoreLine(c, r, dc, dr); // Optional: subtract opponent score if needed
+                score += scoreLine(c, r, dc, dr, color);
+                score -= scoreLine(c, r, dc, dr, opp); // subtract opponent score
             }
         }
     }

--- a/main.cpp
+++ b/main.cpp
@@ -47,6 +47,6 @@ void doPlayerTests()
 
 int main()
 {
-	doPlayerTests();
-	cout << "Passed all tests" << endl;
+        doPlayerTests();
+        cout << "Passed all tests" << endl;
 }


### PR DESCRIPTION
## Summary
- include `<iostream>` so Scaffold display compiles
- add missing `Game` and `GameImpl` declarations
- implement opponent-aware heuristic for `SmartPlayer`
- ensure newline at end of main

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic Game.cpp Players.cpp main.cpp -o game`

------
https://chatgpt.com/codex/tasks/task_e_683fa55d1c348320a2ff7e4a894f3eb6