### PR TITLE
Fix stray semicolons

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -177,8 +177,8 @@ bool GameImpl::completed(int& winner) const
                     winner = BLACK;
                     return true;
                 }
-            };
-        };
+            }
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- remove stray `};` in diagonal check section

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic main.cpp Game.cpp Players.cpp -o connectn`

------
https://chatgpt.com/codex/tasks/task_e_683fadedf8388320a24452e6134ddebe